### PR TITLE
Load forecasting models from SharePoint

### DIFF
--- a/app/utils/forecast.py
+++ b/app/utils/forecast.py
@@ -5,13 +5,17 @@ import os
 from config import BASE_DIR
 from app.utils.data_loader import load_historical_data
 from app.utils.exogenous    import exo_var
+from app.utils.sharepoint   import download_joblib
+
+SP_MODELS_PREFIX = "/sites/ADSODataPerformance/Documents partages/FLux mathéo/streamlit_Flux/models"
+
 
 def load_model_and_scalers(cible):
-    folder = os.path.join(BASE_DIR, 'models', f"{cible}_models")
-    model = joblib.load(os.path.join(folder, f"sarimax_model_{cible}.pkl"))
-    scaler_exog = joblib.load(os.path.join(folder, f"scaler_exog_{cible}.pkl"))
-    scaler_target = joblib.load(os.path.join(folder, f"scaler_target_{cible}.pkl"))
-    pca = joblib.load(os.path.join(folder, f"pca_{cible}.pkl"))
+    folder = f"{SP_MODELS_PREFIX}/{cible}_models"
+    model = download_joblib(f"{folder}/sarimax_model_{cible}.pkl")
+    scaler_exog = download_joblib(f"{folder}/scaler_exog_{cible}.pkl")
+    scaler_target = download_joblib(f"{folder}/scaler_target_{cible}.pkl")
+    pca = download_joblib(f"{folder}/pca_{cible}.pkl")
     return model, scaler_exog, scaler_target, pca
 
 def in_sample_prediction(

--- a/app/utils/sharepoint.py
+++ b/app/utils/sharepoint.py
@@ -1,0 +1,23 @@
+from io import BytesIO
+import os
+import joblib
+from office365.sharepoint.client_context import ClientContext
+from office365.runtime.auth.user_credential import UserCredential
+from office365.sharepoint.files.file import File
+
+
+def download_joblib(server_relative_url: str):
+    """Download a joblib-serialized object from SharePoint.
+
+    Parameters
+    ----------
+    server_relative_url: str
+        Path of the file within the SharePoint site, starting with ``/sites``.
+    """
+    site_url = os.environ["SP_SITE"]
+    user = os.environ.get("SP_USER")
+    password = os.environ.get("SP_PASS")
+
+    ctx = ClientContext(site_url).with_credentials(UserCredential(user, password))
+    response = File.open_binary(ctx, server_relative_url)
+    return joblib.load(BytesIO(response.content))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ joblib
 aiohttp
 holidays
 skopt
+Office365-REST-Python-Client


### PR DESCRIPTION
## Summary
- add SharePoint utility for downloading serialized objects
- load forecasting models directly from SharePoint instead of local files
- include Office365 REST client dependency

## Testing
- `pip install Office365-REST-Python-Client`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a58a500f9c8330975a71d5734899c4